### PR TITLE
leak fix implemented using $^]

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 ---
+changes:
+- Switch from testing $^V to $[ in DESTROY since $^V comparisons leak pre-5.14 (mst)
+---
 version: 0.43
 date:    Wed Jul 20 08:34:01 PDT 2011
 changes:

--- a/lib/IO/All.pm
+++ b/lib/IO/All.pm
@@ -162,7 +162,7 @@ sub READLINE {
 sub DESTROY {
     my $self = shift;
     no warnings;
-    unless ( $^V and $^V lt v5.8.0 ) {
+    unless ( $] < 5.008 ) {
         untie *$self if tied *$self;
     }
     $self->close if $self->is_open;


### PR DESCRIPTION
$^V comparisons leak pre-5.14 - $^] doesn't.
