### PR TITLE
Add a fix for io->file("foobar")->assert.

### DIFF
--- a/lib/IO/All.pm
+++ b/lib/IO/All.pm
@@ -771,13 +771,14 @@ sub throw {
 sub assert_dirpath {
     my $self = shift;
     my $dir_name = shift;
-    return $dir_name if -d $dir_name or
-      CORE::mkdir($self->pathname, $self->perms || 0755) or
+    return $dir_name if ((! CORE::length($dir_name)) or
+      -d $dir_name or
+      CORE::mkdir($dir_name, $self->perms || 0755) or
       do {
           require File::Path;
           File::Path::mkpath($dir_name);
       } or
-      $self->throw("Can't make $dir_name");
+      $self->throw("Can't make $dir_name"));
 }
 
 sub assert_open {

--- a/t/assert.t
+++ b/t/assert.t
@@ -1,16 +1,37 @@
 use lib 't', 'lib';
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 8;
 use IO::All;
 use IO_All_Test;
 
+use Cwd qw(getcwd);
+
 ok(not -e o_dir() . '/newpath/hello.txt');
 ok(not -e o_dir() . '/newpath');
+{
 my $io = io(o_dir() . '/newpath/hello.txt')->assert;
 ok(not -e o_dir() . '/newpath');
 "Hello\n" > $io;
 ok(-f o_dir() . '/newpath/hello.txt');
+}
 
+{
+    my $orig_path = getcwd();
+
+    chdir(o_dir() . '/newpath');
+    # Bug http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=733680
+    "Hello" > io->file('foobar')->assert;
+
+    ok( -f 'foobar');
+    is( scalar (-s 'foobar'), 5);
+
+    "12345678" > io->file('./1_8')->assert;
+
+    ok( -f '1_8', "Dot-slash-assert.");
+    is( scalar (-s '1_8'), 8, "Size is 8.");
+
+    chdir($orig_path);
+}
 
 del_output_dir();


### PR DESCRIPTION
Hi!

Please consider merging these changes, as the functionality of IO::All is broken on some recent versions of GNU/Linux (and it breaks Spork and other things):

This is a fix for http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=733680 .

$ ls -l; echo foo | perl -MIO::All -e 'io("-") > io->file("./bar")->assert'; ls -l
total 0
Can't open file './bar' for output:
Is a directory at -e line 1.
total 0
drwxr-xr-x 1 abe  abe      0 Dec 30 23:51 bar/
$

The culprit appears to be that «-d ""» no longer returns true - it may be
a regression in glibc or the Linux kernel. Anyway, this commit
worksaround it, along with a test. I was able to reproduce it on very
old versions of IO::All so I don't know why it surfaced now.
