### PR TITLE
FIX io->file('') for Win32 systems

### DIFF
--- a/lib/IO/All/File.pm
+++ b/lib/IO/All/File.pm
@@ -14,7 +14,11 @@ sub file {
     my $self = shift;
     bless $self, __PACKAGE__;
     # should we die here if $self->name is already set and there are args?
-    $self->name( $self->_spec_class->catfile( @_ ) ) if @_;
+    if (@_ && @_ > 1) {
+        $self->name( $self->_spec_class->catfile( @_ ) )
+    } elsif (@_) {
+        $self->name($_[0])
+    }
     return $self->_init;
 }
 


### PR DESCRIPTION
- on Win32 systems, t\os.t was failing because "".io->file('') incorrectly returned "\"
- code change/repair was modeled after the repair for dir() in previous commit d35df9357

This fixes the test failure blocking Win32 installations.
