### PR TITLE
FIX dangling file handles in various tests

### DIFF
--- a/t/assert.t
+++ b/t/assert.t
@@ -5,12 +5,13 @@ use Test::More tests => 4;
 use IO::All;
 use IO_All_Test;
 
+{
 ok(not -e o_dir() . '/newpath/hello.txt');
 ok(not -e o_dir() . '/newpath');
 my $io = io(o_dir() . '/newpath/hello.txt')->assert;
 ok(not -e o_dir() . '/newpath');
 "Hello\n" > $io;
 ok(-f o_dir() . '/newpath/hello.txt');
-
+}
 
 del_output_dir();

--- a/t/dbm.t
+++ b/t/dbm.t
@@ -5,12 +5,13 @@ use Test::More tests => 2;
 use IO::All;
 use IO_All_Test;
 
+{
 my $db = io(o_dir() . '/mydbm')->dbm('SDBM_File');
 $db->{fortytwo} = 42;
 $db->{foo} = 'bar';
 
 is(join('', sort keys %$db), 'foofortytwo');
 is(join('', sort values %$db), '42bar');
-
+}
 
 del_output_dir();

--- a/t/lock.t
+++ b/t/lock.t
@@ -9,6 +9,7 @@ $^O !~ /^(cygwin|hpux)$/
     ? print "1..3\n"
     : do { print "1..0 # skip - locking problems on $^O\n"; exit(0) };
 
+{
 my $io1 = io(o_dir() . '/foo')->lock;
 $io1->println('line 1');
 
@@ -28,6 +29,7 @@ $io1->println('line 3');
 $io1->unlock;
 
 waitpid($pid, 0);
+}
 
 del_output_dir();
 

--- a/t/seek.t
+++ b/t/seek.t
@@ -5,10 +5,11 @@ use Test::More tests => 1;
 use IO::All;
 use IO_All_Test;
 
+{
 my $string < (io('t/mystuff') > io(o_dir() . '/seek'));
 my $io = io(o_dir() . '/seek');
 $io->seek(index($string, 'quite'), 0);
 is($io->getline, "quite enough.\n");
-
+}
 
 del_output_dir();

--- a/t/tie_file.t
+++ b/t/tie_file.t
@@ -10,6 +10,7 @@ plan((eval {require Tie::File; 1})
     : (skip_all => "requires Tie::File")
 );
 
+{
 (io(o_dir() . '/tie_file1') < io('t/tie_file.t'))->close;
 my $file = io(o_dir() . '/tie_file1')->rdonly;
 is($file->[-1], 'bar');
@@ -17,6 +18,7 @@ is($file->[-2], 'foo');
 
 "foo\n" x 3 > io(o_dir() . '/tie_file2');
 io(o_dir() . '/tie_file2')->[1] = 'bar';
+}
 
 del_output_dir();
 


### PR DESCRIPTION
- Multiple tests were throwing 'unable to unlink' warnings (under Win32)
- Test directories/files were undeletable because IO objects were not being closed prior to attempting deletion
- Scoping braces were used to simply enable the IO auto-close functionality prior to the directory/file deletions
  - io->close() could have been easily used in some cases, but others were not as obviously repaired; so... scoping instead

This repairs all the test warnings I get when testing on Win32 systems.
