### PR TITLE
speed up repeated initialization of the same type

### DIFF
--- a/Meta
+++ b/Meta
@@ -25,6 +25,7 @@ requires:
   perl: 5.8.1
   Cwd: 0
   Scalar::Util: 0
+  Package::Stash: 0
 
 recommends:
   File::ReadBackwards: 0

--- a/lib/IO/All.pm
+++ b/lib/IO/All.pm
@@ -12,6 +12,7 @@ use File::Spec();
 use Symbol();
 use Fcntl;
 use Cwd ();
+use Package::Stash ();
 
 our @EXPORT = qw(io);
 
@@ -63,8 +64,11 @@ sub AUTOLOAD {
     $self->throw(qq{Can't locate object method "$method" via package "$pkg"})
       if $pkg ne $self->_package;
     my $class = $self->_autoload_class($method);
-    my $foo = "$self";
     bless $self, $class;
+
+    my $stash = Package::Stash->new($pkg);
+    $stash->add_symbol( '&' . $method, sub {my $self = shift; bless $self, $class; $self->$method(@_)} );
+
     $self->$method(@_);
 }
 


### PR DESCRIPTION
Avoid the overhead of AUTOLOAD once a method initializer has been prepared. For an example in a project where I work on AnyData2/DBD::AnyData2 it saves in a test-case 45691 calls to AUTOLOAD and 75.6ms (IO:All::new takes 1.05s - constructions is speed up by 7.2% which is reasonable fast).

If you want to avoid the non-CORE requirement, the line can easily "hacked" by directly modifying the namespace.