### PR TITLE
refs #74 - add cmp overload to fix specific errors in File::Spec::Win32:...

### DIFF
--- a/lib/IO/All.pm
+++ b/lib/IO/All.pm
@@ -1,6 +1,6 @@
 use strict; use warnings;
 package IO::All;
-our $VERSION = '0.86';
+our $VERSION = '0.86.1';
 
 require Carp;
 # So one can use Carp::carp "$message" - without the parenthesis.
@@ -150,6 +150,7 @@ $SIG{__WARN__} = sub {
     }
 };
 
+use overload 'cmp' => '_overload_cmp';
 use overload '""' => '_overload_stringify';
 use overload '|' => '_overload_bitwise_or';
 use overload '<<' => '_overload_left_bitshift';
@@ -243,6 +244,13 @@ sub _get_argument_type {
     $argument->file
       if defined $argument->pathname and not $argument->type;
     return $argument->type || 'unknown';
+}
+
+sub _overload_cmp {
+    my ($self, $other, $swap) = @_;
+    $self = defined($self) ? $self.'' : $self;
+    ($self, $other) = ($other, $self) if $swap;
+    $self cmp $other;
 }
 
 sub _overload_stringify {

--- a/test/overload.t
+++ b/test/overload.t
@@ -1,6 +1,6 @@
 use strict; use warnings;
 my $t; use lib ($t = -e 't' ? 't' : 'test');
-use Test::More tests => 24;
+use Test::More tests => 26;
 use IO_All_Test;
 use IO::All;
 
@@ -86,5 +86,9 @@ test_file_contents2(o_dir() . '/overload1', $cat3);
 
 is "" . ${io($t)}, $t, "scalar overload of directory (for mst)";
 
+#because it broke lots of modules via File::Spec::Win32::catfile/catdir
+my ($f1,$f2) = io->dir( o_dir() )->all;
+ok $f1 ne "", 'string operations overload';
+ok $f1 cmp $f2, 'string operations overload';
 
 del_output_dir();


### PR DESCRIPTION
I've added two tests for that case, in fact not specific to File::Spec::Win32, and I suggest a 'cmp' overload..
