### PR TITLE
protect $! value in _error_check from being stomped upon

### DIFF
--- a/lib/IO/All.pm
+++ b/lib/IO/All.pm
@@ -796,9 +796,10 @@ sub _assert_open {
 
 sub _error_check {
     my $self = shift;
+    my $saved_error = $!;
     return unless $self->io_handle->can('error');
     return unless $self->io_handle->error;
-    $self->throw($!);
+    $self->throw($saved_error);
 }
 
 sub _set_binmode {


### PR DESCRIPTION
I've had a few instances where $! was being stomped in _error_check before it could be thrown. This pull request fixes that behavior by storing it in a temp variable.
