### PR TITLE
defunct [fixes ingydotnet/io-all-pm#95: -utf8 not applied to filenames.]

### DIFF
--- a/lib/IO/All/Dir.pm
+++ b/lib/IO/All/Dir.pm
@@ -178,6 +178,7 @@ sub readdir {
             not /^\.{1,2}$/
         } $self->io_handle->read;
         $self->close;
+        if ($self->_has_utf8) { utf8::decode($_) for (@return) }
         return @return;
     }
     my $name = '.';
@@ -188,6 +189,7 @@ sub readdir {
             return;
         }
     }
+    if ($self->_has_utf8) { utf8::decode($name) }
     return $name;
 }
 

--- a/lib/IO/All/File.pm
+++ b/lib/IO/All/File.pm
@@ -68,9 +68,10 @@ sub assert_tied_file {
         my $name = $self->pathname;
         my @options = $self->_rdonly ? (mode => O_RDONLY) : ();
         push @options, (recsep => $self->separator);
-        tie @$array_ref, 'Tie::File', $name, @options;
-        $self->throw("Can't tie 'Tie::File' to '$name':\n$!")
-          unless tied @$array_ref;
+        my $obj = tie @$array_ref, 'Tie::File', $name, @options
+          or $self->throw("Can't tie 'Tie::File' to '$name':\n$!");
+        $self->io_handle($obj->{fh});
+        $self->_set_binmode;
         $self->tied_file($array_ref);
     };
 }

--- a/lib/IO/All/File.pm
+++ b/lib/IO/All/File.pm
@@ -64,14 +64,14 @@ sub assert_tied_file {
         eval {require Tie::File};
         $self->throw("Tie::File required for file array operations:\n$@")
           if $@;
+        $self->_assert_open;
         my $array_ref = do { my @array; \@array };
         my $name = $self->pathname;
         my @options = $self->_rdonly ? (mode => O_RDONLY) : ();
         push @options, (recsep => $self->separator);
-        my $obj = tie @$array_ref, 'Tie::File', $name, @options
-          or $self->throw("Can't tie 'Tie::File' to '$name':\n$!");
-        $self->io_handle($obj->{fh});
-        $self->_set_binmode;
+        tie @$array_ref, 'Tie::File', $self->io_handle, @options;
+        $self->throw("Can't tie 'Tie::File' to '$name':\n$!")
+          unless tied @$array_ref;
         $self->tied_file($array_ref);
     };
 }


### PR DESCRIPTION
With these two changed lines, the results of directory listings in both scalar and list context are converted to utf8, iff IO::All -utf8 mode has been selected. In other modes the results are unaffected.