### PR TITLE
fixes ingydotnet/io-all-pm#93 and ingydotnet/io-all-pm#95

### DIFF
--- a/lib/IO/All/Dir.pm
+++ b/lib/IO/All/Dir.pm
@@ -178,6 +178,7 @@ sub readdir {
             not /^\.{1,2}$/
         } $self->io_handle->read;
         $self->close;
+        if ($self->_has_utf8) { utf8::decode($_) for (@return) }
         return @return;
     }
     my $name = '.';
@@ -188,6 +189,7 @@ sub readdir {
             return;
         }
     }
+    if ($self->_has_utf8) { utf8::decode($name) }
     return $name;
 }
 

--- a/lib/IO/All/File.pm
+++ b/lib/IO/All/File.pm
@@ -68,9 +68,10 @@ sub assert_tied_file {
         my $name = $self->pathname;
         my @options = $self->_rdonly ? (mode => O_RDONLY) : ();
         push @options, (recsep => $self->separator);
-        tie @$array_ref, 'Tie::File', $name, @options;
-        $self->throw("Can't tie 'Tie::File' to '$name':\n$!")
-          unless tied @$array_ref;
+        my $obj = tie @$array_ref, 'Tie::File', $name, @options
+          or $self->throw("Can't tie 'Tie::File' to '$name':\n$!");
+        $self->io_handle($obj->{fh});
+        $self->_set_binmode;
         $self->tied_file($array_ref);
     };
 }


### PR DESCRIPTION
IO::All::Dir: Return utf8-encoded filenames in '-utf8' mode.
IO::All::File: Correctly encode contents of array-tied file in '-utf8' or other encoding mode.