### PR TITLE
fixes ingydotnet/io-all-pm#93: -utf8 not applied everywhere.

### DIFF
--- a/lib/IO/All/File.pm
+++ b/lib/IO/All/File.pm
@@ -64,11 +64,12 @@ sub assert_tied_file {
         eval {require Tie::File};
         $self->throw("Tie::File required for file array operations:\n$@")
           if $@;
+        $self->_assert_open;
         my $array_ref = do { my @array; \@array };
         my $name = $self->pathname;
         my @options = $self->_rdonly ? (mode => O_RDONLY) : ();
         push @options, (recsep => $self->separator);
-        tie @$array_ref, 'Tie::File', $name, @options;
+        tie @$array_ref, 'Tie::File', $self->io_handle, @options;
         $self->throw("Can't tie 'Tie::File' to '$name':\n$!")
           unless tied @$array_ref;
         $self->tied_file($array_ref);


### PR DESCRIPTION
This pull request ensures correct encoding by first opening the file normally, with all encoding layers being applied, before its file handle is tied to an array reference.