### PR TITLE
fixes ingydotnet/io-all-pm#95: -utf8 not applied to filenames.

### DIFF
--- a/lib/IO/All/Dir.pm
+++ b/lib/IO/All/Dir.pm
@@ -178,6 +178,7 @@ sub readdir {
             not /^\.{1,2}$/
         } $self->io_handle->read;
         $self->close;
+        if ($self->_has_utf8) { utf8::decode($_) for (@return) }
         return @return;
     }
     my $name = '.';
@@ -188,6 +189,7 @@ sub readdir {
             return;
         }
     }
+    if ($self->_has_utf8) { utf8::decode($name) }
     return $name;
 }
 


### PR DESCRIPTION
With these two changed lines, the results of directory listings in both scalar and list context are converted to utf8, iff IO::All -utf8 mode has been selected. In other modes the results are unaffected.
